### PR TITLE
Increase robustiness in resource-constrained environments

### DIFF
--- a/k8s/daemonset.yaml
+++ b/k8s/daemonset.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: doks-debug
+  namespace: kube-system
   labels:
     app: doks-debug
 spec:
@@ -22,11 +23,19 @@ spec:
           privileged: true
         image: digitalocean/doks-debug:latest
         command: [ "sleep", "infinity" ]
+        resources:
+          requests:
+            memory: "32Mi"
+            cpu: "100m"
+          limits:
+            memory: "32Mi"
+            cpu: "100m"
         volumeMounts:
           - name: host
             mountPath: /host
           - name: docker
             mountPath: /var/run/docker.sock
+      priorityClassName: system-cluster-critical
       volumes:
         - name: host
           hostPath:

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: doks-debug
+  namespace: kube-system
   labels:
     app: doks-debug
 spec:
@@ -20,11 +21,19 @@ spec:
           privileged: true
         image: digitalocean/doks-debug:latest
         command: [ "sleep", "infinity" ]
+        resources:
+          requests:
+            memory: "32Mi"
+            cpu: "100m"
+          limits:
+            memory: "32Mi"
+            cpu: "100m"
         volumeMounts:
           - name: host
             mountPath: /host
           - name: docker
             mountPath: /var/run/docker.sock
+      priorityClassName: system-cluster-critical
       volumes:
         - name: host
           hostPath:


### PR DESCRIPTION
This change allows doks-debug to operate in environments where resources are partially constrained, e.g., when nodes are under disk pressure. We do so by turning the pod into a guaranteed one and setting a priority class applicable in DOKS. The latter also requires to run in the kube-system namespace, which is likely a good measure in general.