### PR TITLE
Align and improve DaemonSet / Deployment specs

### DIFF
--- a/k8s/daemonset.yaml
+++ b/k8s/daemonset.yaml
@@ -19,11 +19,6 @@ spec:
       hostNetwork: true
       tolerations:
       - operator: Exists
-        effect: NoExecute
-      - operator: Exists
-        effect: NoSchedule
-      - key: CriticalAddonsOnly
-        operator: Exists
       containers:
       - name: doks-debug
         securityContext:

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -15,6 +15,11 @@ spec:
       labels:
         name: doks-debug
     spec:
+      hostPID: true
+      hostIPC: true
+      hostNetwork: true
+      tolerations:
+      - operator: Exists
       containers:
       - name: doks-debug
         securityContext:


### PR DESCRIPTION
- Use catch-all toleration on both types.
- Enable host{PID,IPC,Network} options on Deployment.