### PR TITLE
Exempt doks-debug from the hostpath-volume clusterlint check

### DIFF
--- a/k8s/daemonset.yaml
+++ b/k8s/daemonset.yaml
@@ -13,6 +13,8 @@ spec:
     metadata:
       labels:
         name: doks-debug
+      annotations:
+        clusterlint.digitalocean.com/disabled-checks: "hostpath-volume"
     spec:
       hostPID: true
       hostIPC: true

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -14,6 +14,8 @@ spec:
     metadata:
       labels:
         name: doks-debug
+      annotations:
+        clusterlint.digitalocean.com/disabled-checks: "hostpath-volume"
     spec:
       hostPID: true
       hostIPC: true


### PR DESCRIPTION
Currently DO's clusterlint tool will flag doks-debug pods because they have hostpath volumes. The hostpath volume usage here is appropriate, so disable the check.
