### PR TITLE
Replace old Travis badge by Github Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 A Docker image with Kubernetes manifests for investigation and troubleshooting your cluster.
 
-[![Build Status](https://travis-ci.org/digitalocean/doks-debug.svg?branch=master)](https://travis-ci.org/digitalocean/doks-debug)
+![main build](https://github.com/digitalocean/doks-debug/actions/workflows/test.yaml/badge.svg) ![main release](https://github.com/digitalocean/doks-debug/actions/workflows/release.yaml/badge.svg)
 
 # Purpose
 


### PR DESCRIPTION
Based on https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge.