### PR TITLE
Dockerfile: align base image version with DOKS worker node OS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # match doks-debug version with DOKS worker node image version for kernel
 # tooling compatibility reasons
-FROM debian:10
+FROM debian:10-slim
 
 WORKDIR /root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update -qq && \
     apt-get install -y apt-transport-https \
                        ca-certificates \
                        software-properties-common \
+                       httping \
                        man \
                        manpages-posix \
                        man-db \

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ RUN apt-get update -qq && \
                        psmisc \
                        dsniff \
                        conntrack \
+                       llvm-8 llvm-8-tools \
                        bpftool
 
 RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ RUN echo 'path-exclude=/usr/share/doc/*' > /etc/dpkg/dpkg.cfg.d/excludes
 RUN echo 'path-include=/usr/share/doc/*/copyright' > /etc/dpkg/dpkg.cfg.d/excludes
 RUN echo 'path-include=/usr/share/doc/*/changelog.Debian.*' > /etc/dpkg/dpkg.cfg.d/excludes
 
+RUN echo 'deb http://deb.debian.org/debian buster-backports main' > /etc/apt/sources.list.d/backports.list
+
 RUN apt-get update -qq && \
     apt-get install -y apt-transport-https \
                        ca-certificates \
@@ -38,7 +40,8 @@ RUN apt-get update -qq && \
                        openssl \
                        psmisc \
                        dsniff \
-                       conntrack
+                       conntrack \
+                       bpftool
 
 RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
     add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,15 @@
-FROM ubuntu:focal
+# match doks-debug version with DOKS worker node image version for kernel
+# tooling compatibility reasons
+FROM debian:10
+
 WORKDIR /root
 
-RUN sed -i '/path-exclude=\/usr\/share\/man\/*/c\#path-exclude=\/usr\/share\/man\/*' /etc/dpkg/dpkg.cfg.d/excludes
+# use same dpkg path-exclude settings that come by default with ubuntu:focal
+# image that we previously used
+RUN echo 'path-exclude=/usr/share/locale/*/LC_MESSAGES/*.mo' > /etc/dpkg/dpkg.cfg.d/excludes
+RUN echo 'path-exclude=/usr/share/doc/*' > /etc/dpkg/dpkg.cfg.d/excludes
+RUN echo 'path-include=/usr/share/doc/*/copyright' > /etc/dpkg/dpkg.cfg.d/excludes
+RUN echo 'path-include=/usr/share/doc/*/changelog.Debian.*' > /etc/dpkg/dpkg.cfg.d/excludes
 
 RUN apt-get update -qq && \
     apt-get install -y apt-transport-https \
@@ -9,11 +17,11 @@ RUN apt-get update -qq && \
                        software-properties-common \
                        httping \
                        man \
-                       manpages-posix \
                        man-db \
                        vim \
                        screen \
                        curl \
+                       gnupg \
                        atop \
                        htop \
                        dstat \
@@ -33,7 +41,7 @@ RUN apt-get update -qq && \
                        conntrack
 
 RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
-    add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" && \
+    add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" && \
     apt-get update -qq && \
     apt-get install -y docker-ce
 


### PR DESCRIPTION
Also install a couple potentially useful tools.

* bpftool: potentially useful for inspecting bpf programs on Linux 5.10
* llvm-8, llvm-8-tools: necessary to perform llvm-objdump to inspect
  BPF programs
* httping: useful for testing http server latency