### PR TITLE
Use ncat instead of netcat

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN apt-get update -qq && \
                        traceroute \
                        iputils-ping \
                        net-tools \
-                       netcat \
+                       ncat \
                        iproute2 \
                        strace \
                        telnet \


### PR DESCRIPTION
When enabling the SCTP IP protocol in cilium 1.13+, we want to test the pod to pod connectivity with a SCTP client and server e2e test using the doks-debug image. We can use `ncat` from the [nmap project](https://nmap.org/ncat/) for that testing scenario and use the `--sctp` flag to specify the protocol. The current `netcat` tooling that is installed in doks-debug does not offer that option. That said, I replaced the package installation script to download `ncat` instead of `netcat`. Diff explanation [here](https://medium.com/@_sathishshan/netcat-vs-ncat-3e5c421db085). 