### PR TITLE
Never block cluster-autoscaler

### DIFF
--- a/k8s/daemonset.yaml
+++ b/k8s/daemonset.yaml
@@ -15,6 +15,7 @@ spec:
         name: doks-debug
       annotations:
         clusterlint.digitalocean.com/disabled-checks: "hostpath-volume"
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
     spec:
       hostPID: true
       hostIPC: true

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -16,6 +16,7 @@ spec:
         name: doks-debug
       annotations:
         clusterlint.digitalocean.com/disabled-checks: "hostpath-volume"
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
     spec:
       hostPID: true
       hostIPC: true


### PR DESCRIPTION
Workloads in the kube-system namespace would block cluster-autoscaler from evicting workloads unless a PDB was defined (see also [this CA FAQ entry](https://github.com/kubernetes/autoscaler/blob/7c86e2813d20db8a943e69e447413ca859b92f97/cluster-autoscaler/FAQ.md#how-to-set-pdbs-to-enable-ca-to-move-kube-system-pods)). Set an annotation to disregard the constraint for doks-debug which should never block evictions and node draining.