### PR TITLE
Upgrade Debian base image to bookworm

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 1
 
       - name: build image
-        run: docker build -t digitalocean/doks-debug:latest .
+        run: docker build --platform linux/amd64 -t digitalocean/doks-debug:latest .
 
       - name: Log into container registry
         run: echo "${{ secrets.DockerHubToken }}" | docker login --username ${DOCKER_USER} --password-stdin

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
           fetch-depth: 1
 
       - name: build image
-        run: docker build -t doks-debug .
+        run: docker build --platform linux/amd64 -t doks-debug .
 
       - name: smoke test
         run: docker run --rm doks-debug sleep 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # match doks-debug version with DOKS worker node image version for kernel
 # tooling compatibility reasons
-FROM debian:10-slim
+FROM debian:12-slim
 
 WORKDIR /root
 
@@ -10,8 +10,6 @@ RUN echo 'path-exclude=/usr/share/locale/*/LC_MESSAGES/*.mo' > /etc/dpkg/dpkg.cf
 RUN echo 'path-exclude=/usr/share/doc/*' > /etc/dpkg/dpkg.cfg.d/excludes
 RUN echo 'path-include=/usr/share/doc/*/copyright' > /etc/dpkg/dpkg.cfg.d/excludes
 RUN echo 'path-include=/usr/share/doc/*/changelog.Debian.*' > /etc/dpkg/dpkg.cfg.d/excludes
-
-RUN echo 'deb http://deb.debian.org/debian buster-backports main' > /etc/apt/sources.list.d/backports.list
 
 RUN apt-get update -qq && \
     apt-get install -y apt-transport-https \
@@ -42,12 +40,12 @@ RUN apt-get update -qq && \
                        dsniff \
                        mtr-tiny \
                        conntrack \
-                       llvm-8 llvm-8-tools \
+                       llvm-13 llvm-13-tools \
                        bpftool
 
 RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
     add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" && \
     apt-get update -qq && \
-    apt-get install -y docker-ce
+    apt-get install -y docker
 
 CMD [ "/bin/bash" ]


### PR DESCRIPTION
As a drive-by, enforce the linux/amd64 to be safe.