### PR TITLE
Use ClusterFirstWithHostNet DNS policy

### DIFF
--- a/k8s/daemonset.yaml
+++ b/k8s/daemonset.yaml
@@ -17,6 +17,7 @@ spec:
         clusterlint.digitalocean.com/disabled-checks: "hostpath-volume"
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
     spec:
+      dnsPolicy: ClusterFirstWithHostNet
       hostPID: true
       hostIPC: true
       hostNetwork: true

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -18,6 +18,7 @@ spec:
         clusterlint.digitalocean.com/disabled-checks: "hostpath-volume"
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
     spec:
+      dnsPolicy: ClusterFirstWithHostNet
       hostPID: true
       hostIPC: true
       hostNetwork: true


### PR DESCRIPTION
Simplifies testing in-cluster DNS as the policy enables to query CoreDNS for such requests.