### PR TITLE
remove docker socket mounts and cli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,9 +44,4 @@ RUN apt-get update -qq && \
                        llvm-13 llvm-13-tools \
                        bpftool
 
-RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
-    add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" && \
-    apt-get update -qq && \
-    apt-get install -y docker
-
 CMD [ "/bin/bash" ]

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ This DaemonSet manifest will:
  1. Ensure a pod with our Docker image is running indefinitely on every node.
  2. Use `hostPID`, `hostIPC`, and `hostNetwork`.
  3. Mount the entire host filesystem to `/host` in the containers.
- 4. Mount `/var/run/docker.sock` from the host.
 
 In order to make use of these workloads, you can exec into a pod of choice by name:
 
@@ -47,7 +46,6 @@ Once you're in, you have access to the set of tools listed in the `Dockerfile`. 
  - [`netcat`](https://linux.die.net/man/1/nc) - is a multi-tool for interacting with TCP and UDP; it can open TCP connections, send UDP packets, listen on arbitrary TCP and UDP ports, do port scanning, and deal with both IPv4 and IPv6.
  - [`iproute2`](https://wiki.linuxfoundation.org/networking/iproute2) - is a collection of utilities for controlling TCP / IP networking and traffic control in Linux.
  - [`strace`](https://github.com/strace/strace) - is a diagnostic, debugging and instructional userspace utility with a traditional command-line interface for Linux. It is used to monitor and tamper with interactions between processes and the Linux kernel, which include system calls, signal deliveries, and changes of process state.
- - [`docker`](https://docs.docker.com/engine/reference/commandline/cli/) - is the CLI tool used for interacting with Docker containers on the system.
  - [`dstat`](http://dag.wiee.rs/home-made/dstat/) - is a versatile replacement for vmstat, iostat, netstat and ifstat. Dstat overcomes some of their limitations and adds some extra features, more counters and flexibility. Dstat is handy for monitoring systems during performance tuning tests, benchmarks or troubleshooting.
  - [`htop`](https://hisham.hm/htop/) - is interactive process viewer for Unix systems.
  - [`atop`](https://www.atoptool.nl/) - is an advanced interactive monitor for Linux-systems to view the load on system-level and process-level.

--- a/k8s/daemonset.yaml
+++ b/k8s/daemonset.yaml
@@ -39,17 +39,11 @@ spec:
         volumeMounts:
           - name: host
             mountPath: /host
-          - name: docker
-            mountPath: /var/run/docker.sock
       terminationGracePeriodSeconds: 0
       volumes:
         - name: host
           hostPath:
             path: /
-        - name: docker
-          hostPath:
-            path: /var/run/docker.sock
-            type: Socket
   updateStrategy:
     rollingUpdate:
       maxSurge: 0

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -40,17 +40,11 @@ spec:
         volumeMounts:
           - name: host
             mountPath: /host
-          - name: docker
-            mountPath: /var/run/docker.sock
       terminationGracePeriodSeconds: 0
       volumes:
         - name: host
           hostPath:
             path: /
-        - name: docker
-          hostPath:
-            path: /var/run/docker.sock
-            type: Socket
   strategy:
     rollingUpdate:
       maxSurge: 0


### PR DESCRIPTION
doks switched to containerd container runtime a while ago (https://docs.digitalocean.com/products/kubernetes/details/changelog/#1.20.2-do.0), so while docker is still installed on the nodes it's not useful for debugging k8s containers anymore