### PR TITLE
Add support for crictl into the base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,10 @@ WORKDIR /root
 
 # use same dpkg path-exclude settings that come by default with ubuntu:focal
 # image that we previously used
-RUN echo 'path-exclude=/usr/share/locale/*/LC_MESSAGES/*.mo' > /etc/dpkg/dpkg.cfg.d/excludes
-RUN echo 'path-exclude=/usr/share/doc/*' > /etc/dpkg/dpkg.cfg.d/excludes
-RUN echo 'path-include=/usr/share/doc/*/copyright' > /etc/dpkg/dpkg.cfg.d/excludes
-RUN echo 'path-include=/usr/share/doc/*/changelog.Debian.*' > /etc/dpkg/dpkg.cfg.d/excludes
+RUN echo 'path-exclude=/usr/share/locale/*/LC_MESSAGES/*.mo' >> /etc/dpkg/dpkg.cfg.d/excludes
+RUN echo 'path-exclude=/usr/share/doc/*' >> /etc/dpkg/dpkg.cfg.d/excludes
+RUN echo 'path-include=/usr/share/doc/*/copyright' ≥> /etc/dpkg/dpkg.cfg.d/excludes
+RUN echo 'path-include=/usr/share/doc/*/changelog.Debian.*' ≥> /etc/dpkg/dpkg.cfg.d/excludes
 
 RUN apt-get update -qq && \
     apt-get install -y apt-transport-https \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,17 @@
 # tooling compatibility reasons
 FROM debian:12-slim
 
+# Specify the version of crictl to install
+ARG CRICTL_VERSION="v1.31.1"
+
 WORKDIR /root
 
 # use same dpkg path-exclude settings that come by default with ubuntu:focal
 # image that we previously used
 RUN echo 'path-exclude=/usr/share/locale/*/LC_MESSAGES/*.mo' >> /etc/dpkg/dpkg.cfg.d/excludes
 RUN echo 'path-exclude=/usr/share/doc/*' >> /etc/dpkg/dpkg.cfg.d/excludes
-RUN echo 'path-include=/usr/share/doc/*/copyright' ≥> /etc/dpkg/dpkg.cfg.d/excludes
-RUN echo 'path-include=/usr/share/doc/*/changelog.Debian.*' ≥> /etc/dpkg/dpkg.cfg.d/excludes
+RUN echo 'path-include=/usr/share/doc/*/copyright' >> /etc/dpkg/dpkg.cfg.d/excludes
+RUN echo 'path-include=/usr/share/doc/*/changelog.Debian.*' >> /etc/dpkg/dpkg.cfg.d/excludes
 
 RUN apt-get update -qq && \
     apt-get install -y apt-transport-https \
@@ -42,6 +45,17 @@ RUN apt-get update -qq && \
                        mtr-tiny \
                        conntrack \
                        llvm-13 llvm-13-tools \
+                       wget \
                        bpftool
+
+# Install crictl
+RUN wget https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRICTL_VERSION}/crictl-${CRICTL_VERSION}-linux-amd64.tar.gz && \
+    tar zxvf crictl-${CRICTL_VERSION}-linux-amd64.tar.gz -C /usr/local/bin && \
+    rm -f crictl-${CRICTL_VERSION}-linux-amd64.tar.gz
+
+# Specify the default image endpoint for crictl
+RUN echo 'runtime-endpoint: unix:///run/containerd/containerd.sock' >> /etc/crictl.yaml
+RUN echo 'image-endpoint: unix:///run/containerd/containerd.sock' >> /etc/crictl.yaml
+RUN echo 'timeout: 2' >> /etc/crictl.yaml
 
 CMD [ "/bin/bash" ]

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This DaemonSet manifest will:
  1. Ensure a pod with our Docker image is running indefinitely on every node.
  2. Use `hostPID`, `hostIPC`, and `hostNetwork`.
  3. Mount the entire host filesystem to `/host` in the containers.
+ 4. Mount the `containerd` socket at `/run/containerd/containerd.sock` from the host into the container.
 
 In order to make use of these workloads, you can exec into a pod of choice by name:
 
@@ -49,7 +50,9 @@ Once you're in, you have access to the set of tools listed in the `Dockerfile`. 
  - [`dstat`](http://dag.wiee.rs/home-made/dstat/) - is a versatile replacement for vmstat, iostat, netstat and ifstat. Dstat overcomes some of their limitations and adds some extra features, more counters and flexibility. Dstat is handy for monitoring systems during performance tuning tests, benchmarks or troubleshooting.
  - [`htop`](https://hisham.hm/htop/) - is interactive process viewer for Unix systems.
  - [`atop`](https://www.atoptool.nl/) - is an advanced interactive monitor for Linux-systems to view the load on system-level and process-level.
-
+ - [`atop`](https://www.atoptool.nl/) - is an advanced interactive monitor for Linux-systems to view the load on system-level and process-level.
+ - [`wget`](https://www.gnu.org/software/wget/) - for retrieving files using HTTP, HTTPS, FTP and FTPS.
+ - [`crictl`](https://github.com/kubernetes-sigs/cri-tools/blob/master/docs/crictl.md) - A CLI for CRI endpoints. Configured to use `/run/containerd/containerd.sock` as a default endpoint. 
 # Tips and Tricks
 
 ## chroot + systemctl

--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ Once you're in, you have access to the set of tools listed in the `Dockerfile`. 
  - [`dstat`](http://dag.wiee.rs/home-made/dstat/) - is a versatile replacement for vmstat, iostat, netstat and ifstat. Dstat overcomes some of their limitations and adds some extra features, more counters and flexibility. Dstat is handy for monitoring systems during performance tuning tests, benchmarks or troubleshooting.
  - [`htop`](https://hisham.hm/htop/) - is interactive process viewer for Unix systems.
  - [`atop`](https://www.atoptool.nl/) - is an advanced interactive monitor for Linux-systems to view the load on system-level and process-level.
- - [`atop`](https://www.atoptool.nl/) - is an advanced interactive monitor for Linux-systems to view the load on system-level and process-level.
  - [`wget`](https://www.gnu.org/software/wget/) - for retrieving files using HTTP, HTTPS, FTP and FTPS.
  - [`crictl`](https://github.com/kubernetes-sigs/cri-tools/blob/master/docs/crictl.md) - A CLI for CRI endpoints. Configured to use `/run/containerd/containerd.sock` as a default endpoint. 
 # Tips and Tricks

--- a/k8s/daemonset.yaml
+++ b/k8s/daemonset.yaml
@@ -39,11 +39,17 @@ spec:
         volumeMounts:
           - name: host
             mountPath: /host
+          - name: containerd
+            mountPath: /run/containerd/containerd.sock
       terminationGracePeriodSeconds: 0
       volumes:
         - name: host
           hostPath:
             path: /
+        - name: containerd
+          hostPath:
+            path: /run/containerd/containerd.sock
+            type: Socket
   updateStrategy:
     rollingUpdate:
       maxSurge: 0

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -40,11 +40,17 @@ spec:
         volumeMounts:
           - name: host
             mountPath: /host
+          - name: containerd
+            mountPath: /run/containerd/containerd.sock
       terminationGracePeriodSeconds: 0
       volumes:
         - name: host
           hostPath:
             path: /
+        - name: containerd
+          hostPath:
+            path: /run/containerd/containerd.sock
+            type: Socket
   strategy:
     rollingUpdate:
       maxSurge: 0


### PR DESCRIPTION
- Updated the dockerfile to download crictl and wget (to download the tar.gz from GH)
- Fixed shell redirection for some lines as a small fix, as otherwise they were just overwriting the files
- Updated the daemonset and deployment